### PR TITLE
fix: ビルドエラーを解決

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "build:static": "next build && next export",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv env.d.ts",
     "check": "npm run build && tsc",
     "deploy": "npm run build && opennextjs-cloudflare deploy",

--- a/src/app/wiki/[[...slug]]/page.tsx
+++ b/src/app/wiki/[[...slug]]/page.tsx
@@ -4,9 +4,9 @@ import { markdownToHtml } from '@/lib/markdown';
 import { WikiLayout } from '@/components/wiki-layout';
 
 interface PageProps {
-  params: {
+  params: Promise<{
     slug?: string[];
-  };
+  }>;
 }
 
 export async function generateStaticParams() {
@@ -24,8 +24,8 @@ export async function generateStaticParams() {
 }
 
 export default async function WikiPage({ params }: PageProps) {
-  const { slug: paramSlug } = await params;
-  const slug = paramSlug || ['index'];
+  const resolvedParams = await params;
+  const slug = resolvedParams.slug || ['index'];
   const doc = await getDocBySlug(slug);
   const tree = getDocsTree();
 

--- a/src/components/mobile-sidebar.tsx
+++ b/src/components/mobile-sidebar.tsx
@@ -13,7 +13,15 @@ import { WikiSidebar } from './wiki-sidebar';
 import { useState } from 'react';
 
 interface MobileSidebarProps {
-  tree: any[];
+  tree: DocItem[];
+}
+
+interface DocItem {
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+  title?: string;
+  children?: DocItem[];
 }
 
 export function MobileSidebar({ tree }: MobileSidebarProps) {

--- a/src/components/wiki-layout.tsx
+++ b/src/components/wiki-layout.tsx
@@ -1,13 +1,20 @@
 import { WikiSidebar } from './wiki-sidebar';
-import { Separator } from '@/components/ui/separator';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { MobileSidebar } from './mobile-sidebar';
 import { Github, Package } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
+interface DocItem {
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+  title?: string;
+  children?: DocItem[];
+}
+
 interface WikiLayoutProps {
   children: React.ReactNode;
-  tree: any[];
+  tree: DocItem[];
 }
 
 export function WikiLayout({ children, tree }: WikiLayoutProps) {


### PR DESCRIPTION
package.jsonから静的ビルドスクリプトを削除し、WikiPageコンポーネントでのパラメータ解決方法を修正。MobileSidebarおよびWikiLayoutコンポーネントの型定義を強化し、getDocsTree関数の戻り値の型を明確化。