### PR TITLE
fix: ビルドスクリプトの改善

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,12 +51,13 @@
   "private": true,
   "scripts": {
     "build": "next build",
+    "build:open-next": "opennextjs-cloudflare build",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv env.d.ts",
     "check": "npm run build && tsc",
-    "deploy": "npm run build && opennextjs-cloudflare deploy",
+    "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "dev": "next dev",
     "lint": "next lint",
-    "preview": "npm run build && opennextjs-cloudflare preview",
+    "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "start": "next start"
   }
 }


### PR DESCRIPTION
package.jsonに新しいビルドスクリプト「build:open-next」を追加し、既存の「deploy」と「preview」スクリプトを修正して、opennextjs-cloudflareを使用するように変更。