### PR TITLE
fix: ドキュメントツリーの取得方法を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ next-env.d.ts
 # wrangler files
 .wrangler
 .dev.vars*
+
+# generated data
+src/data/docs-tree.json

--- a/package.json
+++ b/package.json
@@ -50,14 +50,15 @@
   },
   "private": true,
   "scripts": {
+    "prebuild": "node scripts/generate-docs-data.js",
     "build": "next build",
     "build:open-next": "opennextjs-cloudflare build",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv env.d.ts",
     "check": "npm run build && tsc",
-    "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+    "deploy": "npm run prebuild && opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "dev": "next dev",
     "lint": "next lint",
-    "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
+    "preview": "npm run prebuild && opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "start": "next start"
   }
 }

--- a/scripts/generate-docs-data.js
+++ b/scripts/generate-docs-data.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+const docsDirectory = path.join(process.cwd(), 'docs');
+const outputPath = path.join(process.cwd(), 'src/data/docs-tree.json');
+
+function buildTree(dirPath = '') {
+  const fullPath = path.join(docsDirectory, dirPath);
+  const entries = fs.readdirSync(fullPath, { withFileTypes: true });
+  
+  const items = [];
+  
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const children = buildTree(path.join(dirPath, entry.name));
+      if (children.length > 0) {
+        items.push({
+          name: entry.name,
+          path: path.join(dirPath, entry.name),
+          type: 'directory',
+          children,
+        });
+      }
+    } else if (entry.name.endsWith('.md')) {
+      const slug = entry.name.replace(/\.md$/, '');
+      const fullSlug = dirPath ? path.join(dirPath, slug).split(path.sep) : [slug];
+      
+      try {
+        const filePath = path.join(docsDirectory, ...fullSlug) + '.md';
+        const fileContents = fs.readFileSync(filePath, 'utf8');
+        const { data } = matter(fileContents);
+        
+        items.push({
+          name: slug,
+          path: path.join(dirPath, slug),
+          type: 'file',
+          title: data.title || slug.replace(/-/g, ' '),
+          order: data.order,
+        });
+      } catch (err) {
+        console.error(`Error reading ${entry.name}:`, err);
+      }
+    }
+  }
+  
+  return items.sort((a, b) => {
+    if (a.order !== undefined && b.order !== undefined) {
+      return a.order - b.order;
+    }
+    if (a.order !== undefined) return -1;
+    if (b.order !== undefined) return 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+// Generate the tree
+const tree = buildTree();
+
+// Ensure the data directory exists
+const dataDir = path.dirname(outputPath);
+if (!fs.existsSync(dataDir)) {
+  fs.mkdirSync(dataDir, { recursive: true });
+}
+
+// Write the tree to a JSON file
+fs.writeFileSync(outputPath, JSON.stringify(tree, null, 2));
+
+console.log('✅ Docs tree generated at:', outputPath);
+console.log('📄 Total items:', JSON.stringify(tree, null, 2).split('"type"').length - 1);

--- a/src/app/wiki/[[...slug]]/page.tsx
+++ b/src/app/wiki/[[...slug]]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
-import { getDocBySlug, getDocSlugs, getDocsTree } from '@/lib/docs';
+import { getDocBySlug, getDocSlugs } from '@/lib/docs';
+import { getDocsTreeStatic } from '@/lib/docs-static';
 import { markdownToHtml } from '@/lib/markdown';
 import { WikiLayout } from '@/components/wiki-layout';
 
@@ -27,7 +28,7 @@ export default async function WikiPage({ params }: PageProps) {
   const resolvedParams = await params;
   const slug = resolvedParams.slug || ['index'];
   const doc = await getDocBySlug(slug);
-  const tree = getDocsTree();
+  const tree = getDocsTreeStatic();
 
   if (!doc) {
     notFound();

--- a/src/lib/docs-static.ts
+++ b/src/lib/docs-static.ts
@@ -1,0 +1,14 @@
+import docsTreeData from '@/data/docs-tree.json';
+
+interface TreeItem {
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+  title?: string;
+  order?: number;
+  children?: TreeItem[];
+}
+
+export function getDocsTreeStatic(): TreeItem[] {
+  return docsTreeData as TreeItem[];
+}


### PR DESCRIPTION
WikiPageコンポーネントでgetDocsTree関数をgetDocsTreeStaticに置き換え、.gitignoreに生成データ用のファイルを追加。package.jsonにprebuildスクリプトを追加し、deployおよびpreviewスクリプトを修正。