### PR TITLE
fix: Cloudflareとの互換性向上と静的生成の改善

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,22 +1,21 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // Cloudflare Pages doesn't support image optimization
+  // Cloudflare doesn't support image optimization
   images: {
     unoptimized: true,
   },
   
-  // For Cloudflare Pages compatibility
+  // Output type for Cloudflare Workers
+  // Note: 'export' is deprecated in Next.js 15+
+  output: undefined,
+  
+  // For better URL handling
   trailingSlash: false,
   
-  // Skip TypeScript errors during build
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  
-  // Skip ESLint during build
-  eslint: {
-    ignoreDuringBuilds: true,
+  // Ensure proper static generation
+  generateBuildId: async () => {
+    return 'pika-wiki-build';
   },
 };
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,10 +6,12 @@
   "name": "pika-wiki",
   "main": ".open-next/worker.js",
   "compatibility_date": "2025-04-01",
-  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public", "assets_navigation_prefers_asset_serving"],
   "assets": {
     "binding": "ASSETS",
-    "directory": ".open-next/assets"
+    "directory": ".open-next/assets",
+    "not_found_handling": "single-page-application",
+    "html_handling": "auto-trailing-slash"
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
next.config.tsでCloudflareの画像最適化に関するコメントを修正し、出力タイプを未定義に設定。trailingSlashをfalseに維持し、静的生成のためのgenerateBuildIdを追加。wrangler.jsoncでは、互換性フラグに新しいオプションを追加し、アセットのディレクトリ設定を更新。