### PR TITLE
fix: wrangler.jsoncの互換性フラグを更新

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,7 +6,7 @@
   "name": "pika-wiki",
   "main": ".open-next/worker.js",
   "compatibility_date": "2025-04-01",
-  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public", "assets_navigation_prefers_asset_serving"],
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "assets": {
     "binding": "ASSETS",
     "directory": ".open-next/assets",


### PR DESCRIPTION
wrangler.jsoncで互換性フラグから不要なオプションを削除し、設定を簡素化しました。